### PR TITLE
Update vpc-peering-security-groups.md

### DIFF
--- a/doc_source/vpc-peering-security-groups.md
+++ b/doc_source/vpc-peering-security-groups.md
@@ -2,18 +2,12 @@
 
 You can update the inbound or outbound rules for your VPC security groups to reference security groups in the peered VPC\. Doing so allows traffic to flow to and from instances that are associated with the referenced security group in the peered VPC\.
 
-## Notes about referencing Peer VPCs in Security Group Rules
-1. Security groups in a peer VPC are not automatically populated in the list\.
+**Requirements**
++ The peer VPC can be a VPC in your account , or a VPC in another AWS account. To reference a security group owned by another AWS account, include the account number in the **Source** or **Destination** field; for example, `123456789012/sg-1a2b3c4d`\.
++ You cannot reference the security group of a peer VPC that's in a different region. Instead, use the CIDR block of the peer VPC\.
++ To reference a security group in a peer VPC, the VPC peering connection must be in the `active` state\. 
 
-2. A security group owned by another AWS account must be prefixed with the remote security group's account number when used in the **Source** or **Destination** field, for example, `123456789012/sg-1a2b3c4d`\.
-
-3. Since you cannot reference the security group of a peer VPC that's in a different region, use the remote peer's CIDR block instead of the remote peer's security group name\.
-
-4. To reference a security group in a peer VPC, the VPC peering connection must be in the `active` state\. 
-
-5. The peer VPC can be a VPC in your account, or a VPC in another AWS account\. You cannot reference the security group of a peer VPC that's in a different region\.  Instead, use the remote peer's CIDR block.
-
-## Update your security group rules via the console
+**To update your security group rules using the console**
 
 1. Open the Amazon VPC console at [https://console\.aws\.amazon\.com/vpc/](https://console.aws.amazon.com/vpc/)\.
 
@@ -24,28 +18,28 @@ You can update the inbound or outbound rules for your VPC security groups to ref
 1. Choose **Edit**, **Add another rule**\.
 
 1. Specify the type, protocol, and port range as required\. For **Source** \(or **Destination** for an outbound rule\), enter the ID of the security group in the peer VPC\.
+**Note**  
+Security groups in a peer VPC are not automatically in this list\.
 
 1. Choose **Save**\.
 
-## Update your security group rules via aws cli
+**To update inbound rules using the command line**
++ [authorize\-security\-group\-ingress](http://docs.aws.amazon.com/cli/latest/reference/ec2/authorize-security-group-ingress.html) \(AWS CLI\)
++ [Grant\-EC2SecurityGroupIngress](http://docs.aws.amazon.com/powershell/latest/reference/items/Grant-EC2SecurityGroupIngress.html) \(AWS Tools for Windows PowerShell\)
++ [Revoke\-EC2SecurityGroupIngress](http://docs.aws.amazon.com/powershell/latest/reference/items/Revoke-EC2SecurityGroupIngress.html) \(AWS Tools for Windows PowerShell\)
++ [revoke\-security\-group\-ingress](http://docs.aws.amazon.com/cli/latest/reference/ec2/revoke-security-group-ingress.html) \(AWS CLI\)
 
-Alternatively, you can use the following cli commands\:
-
-
-| Action | Commands | 
-| --- | --- | 
-| Authorize inbound rules |  [authorize\-security\-group\-ingress](http://docs.aws.amazon.com/cli/latest/reference/ec2/authorize-security-group-ingress.html) \(AWS CLI\) [Grant\-EC2SecurityGroupIngress](http://docs.aws.amazon.com/powershell/latest/reference/items/Grant-EC2SecurityGroupIngress.html) \(AWS Tools for Windows PowerShell\)  | 
-| Authorize outbound rules |  [authorize\-security\-group\-egress](http://docs.aws.amazon.com/cli/latest/reference/ec2/authorize-security-group-egress.html) \(AWS CLI\) [Grant\-EC2SecurityGroupEgress](http://docs.aws.amazon.com/powershell/latest/reference/items/Grant-EC2SecurityGroupEgress.html) \(AWS Tools for Windows PowerShell\)  | 
-| Revoke inbound rules |  [revoke\-security\-group\-ingress](http://docs.aws.amazon.com/cli/latest/reference/ec2/revoke-security-group-ingress.html) \(AWS CLI\) [Revoke\-EC2SecurityGroupIngress](http://docs.aws.amazon.com/powershell/latest/reference/items/Revoke-EC2SecurityGroupIngress.html) \(AWS Tools for Windows PowerShell\)  | 
-| Revoke outbound rules |  [revoke\-security\-group\-egress](http://docs.aws.amazon.com/cli/latest/reference/ec2/revoke-security-group-egress.html) \(AWS CLI\) [Revoke\-EC2SecurityGroupEgress](http://docs.aws.amazon.com/powershell/latest/reference/items/Revoke-EC2SecurityGroupEgress.html) \(AWS Tools for Windows PowerShell\)  | 
+**To update outbound rules using the command line**
++ [authorize\-security\-group\-egress](http://docs.aws.amazon.com/cli/latest/reference/ec2/authorize-security-group-egress.html) \(AWS CLI\)
++ [Grant\-EC2SecurityGroupEgress](http://docs.aws.amazon.com/powershell/latest/reference/items/Grant-EC2SecurityGroupEgress.html) \(AWS Tools for Windows PowerShell\)
++ [Revoke\-EC2SecurityGroupEgress](http://docs.aws.amazon.com/powershell/latest/reference/items/Revoke-EC2SecurityGroupEgress.html) \(AWS Tools for Windows PowerShell\)
++ [revoke\-security\-group\-egress](http://docs.aws.amazon.com/cli/latest/reference/ec2/revoke-security-group-egress.html) \(AWS CLI\)
 
 For example, to update your security group `sg-aaaa1111` to allow inbound access over HTTP from `sg-bbbb2222` that's in a peer VPC, you can use the following AWS CLI command:
 
 ```
 aws ec2 authorize-security-group-ingress --group-id sg-aaaa1111 --protocol tcp --port 80 --source-group sg-bbbb2222 
 ```
-
-The peer VPC can be a VPC in your account, or a VPC in another AWS account\.
 
 After you've updated the security group rules, use the [describe\-security\-groups](http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-security-groups.html) command to view the referenced security group in your security group rules\. 
 
@@ -73,9 +67,6 @@ aws ec2 describe-security-group-references --group-id sg-bbbb2222
   ]
 }
 ```
-
-**Note**  
-Currently, you cannot identify security group references using the Amazon VPC or Amazon EC2 consoles\.
 
 If the VPC peering connection is deleted, or if the owner of the peer VPC deletes the referenced security group, the security group rule becomes stale\. 
 

--- a/doc_source/vpc-peering-security-groups.md
+++ b/doc_source/vpc-peering-security-groups.md
@@ -2,11 +2,18 @@
 
 You can update the inbound or outbound rules for your VPC security groups to reference security groups in the peered VPC\. Doing so allows traffic to flow to and from instances that are associated with the referenced security group in the peered VPC\.
 
-To reference a security group in a peer VPC, the VPC peering connection must be in the `active` state\. 
+## Notes about referencing Peer VPCs in Security Group Rules
+1. Security groups in a peer VPC are not automatically populated in the list\.
 
-The peer VPC can be a VPC in your account, or a VPC in another AWS account\. You cannot reference the security group of a peer VPC that's in a different region\.
+2. A security group owned by another AWS account must be prefixed with the remote security group's account number when used in the **Source** or **Destination** field, for example, `123456789012/sg-1a2b3c4d`\.
 
-**To update your security group rules**
+3. Since you cannot reference the security group of a peer VPC that's in a different region, use the remote peer's CIDR block instead of the remote peer's security group name\.
+
+4. To reference a security group in a peer VPC, the VPC peering connection must be in the `active` state\. 
+
+5. The peer VPC can be a VPC in your account, or a VPC in another AWS account\. You cannot reference the security group of a peer VPC that's in a different region\.  Instead, use the remote peer's CIDR block.
+
+## Update your security group rules via the console
 
 1. Open the Amazon VPC console at [https://console\.aws\.amazon\.com/vpc/](https://console.aws.amazon.com/vpc/)\.
 
@@ -17,14 +24,12 @@ The peer VPC can be a VPC in your account, or a VPC in another AWS account\. You
 1. Choose **Edit**, **Add another rule**\.
 
 1. Specify the type, protocol, and port range as required\. For **Source** \(or **Destination** for an outbound rule\), enter the ID of the security group in the peer VPC\.
-**Note**  
-Security groups in a peer VPC are not automatically populated in the list\.
 
 1. Choose **Save**\.
 
-A security group that references a security group in another AWS account includes the account number in **Source** or **Destination** field; for example, `123456789012/sg-1a2b3c4d`\.
+## Update your security group rules via aws cli
 
-Alternatively, you can use the following commands\.
+Alternatively, you can use the following cli commands\:
 
 
 | Action | Commands | 


### PR DESCRIPTION
Since there are many notes, instead of calling them out individually as notes, just make a notes section and place them all there.  Also, more formally define console vs cli sections.

In addition, give the instruction to the user to use the remote CIDR block vs the remote SG name when referencing a remote peer's SG.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
