### PR TITLE
Update vpc-peering-security-groups.md

### DIFF
--- a/doc_source/vpc-peering-security-groups.md
+++ b/doc_source/vpc-peering-security-groups.md
@@ -72,7 +72,7 @@ If the VPC peering connection is deleted, or if the owner of the peer VPC delete
 
 ## Working with Stale Security Group Rules<a name="vpc-peering-stale-groups"></a>
 
-A stale security group rule is a rule that references a security group in a peer VPC where the VPC peering connection has been deleted or the security group in the peer VPC has been deleted\. When a security group rule becomes stale, it's not automatically removed from your security group—you must manually remove it\. If a security group rule was stale because the VPC peering connection was deleted and you then create a new VPC peering connection with the same VPCs, it will no longer be marked as stale\.
+A stale security group rule is a rule that references a security group in a peer VPC where the VPC peering connection has been deleted or the security group in the peer VPC has been deleted\. When a security group rule becomes stale, it's not automatically removed from your security group—you must manually remove it\. If a security group rule is stale because the VPC peering connection was deleted, the rule will no longer be marked as stale if you create a new VPC peering connection with the same VPCs. 
 
 You can view and delete the stale security group rules for a VPC using the Amazon VPC console\.
 


### PR DESCRIPTION
The use of the word "was" on line #75 is awkward.  I reworded the sentence so that "is stale" is used.  The sentence might be grammatically correct but I think it is awkward to use "was stale" and the phrase "and then create".  The reason being is that at the time a new vpc connection is created the rule "is stale" rather than "was stale". 

Thank you for taking the time to consider my proposed change.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
